### PR TITLE
FEAT: Separate `KeepAlive` Module from `init`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ RUN apk add --no-cache build-base
 
 COPY Init.c Init.c
 
-RUN gcc -o Init.out -Ofast Init.c
+COPY KeepAlive.c KeepAlive.c
+
+RUN gcc -o Init.out -Ofast Init.c \
+ && gcc -o KeepAlive.out -Ofast KeepAlive.c
 
 FROM alpine:3
 
@@ -20,5 +23,7 @@ ENV RPI_RCSID=REPLACE_ME \
 COPY .FILES/squid.conf /etc/squid/squid.conf
 
 COPY --from=0 /Init.out /usr/bin/init
+
+COPY --from=0 /KeepAlive.out /usr/bin/vpnKeepAlive
 
 ENTRYPOINT ["/usr/bin/init"]

--- a/Init.c
+++ b/Init.c
@@ -123,19 +123,17 @@ void runService_VPNKeepAlive(void) {
          VPN_KEEPALIVE, " Seconds");
   fflush(stdout);
 
-  while (1) {
-    pid_t pidKeepAlive = fork();
-    if (unlikely(pidKeepAlive == -1)) {
-      printf("\033[0;31m%s\033[0m%s\n", "ERROR: ", "Failed to Fork");
-      exit(EXIT_FAILURE);
-    } else if (pidKeepAlive == 0) {
-      fclose(stdin);
-      freopen("/dev/null", "w", stdout);
-      freopen("/dev/null", "w", stderr);
-      execl("/bin/ping", "ping", "-c", "1", "roundcube.rpi.edu", NULL);
-    }
-    waitpid(pidKeepAlive, NULL, 0);
-    sleep(VPN_KEEPALIVE);
+  pid_t pidKeepAlive = fork();
+  if (unlikely(pidKeepAlive == -1)) {
+    printf("\033[0;31m%s\033[0m%s\n", "ERROR: ", "Failed to Fork");
+    exit(EXIT_FAILURE);
+  } else if (pidKeepAlive == 0) {
+    char STRING_VPN_KEEPALIVE[sizeof(unsigned int)] = {};
+    sprintf(STRING_VPN_KEEPALIVE, "%u", VPN_KEEPALIVE);
+    fclose(stdin);
+    freopen("/dev/null", "w", stdout);
+    freopen("/dev/null", "w", stderr);
+    execl("/usr/bin/vpnKeepAlive", "vpnKeepAlive", STRING_VPN_KEEPALIVE, NULL);
   }
 }
 
@@ -151,6 +149,11 @@ int main(void) {
   runService_OpenConnect();
 
   runService_VPNKeepAlive();
+
+  // Collect Zombine Process
+  while (1) {
+    waitpid(-1, NULL, 0);
+  }
 
   return EXIT_SUCCESS;
 }

--- a/Init.c
+++ b/Init.c
@@ -128,7 +128,7 @@ void runService_VPNKeepAlive(void) {
     printf("\033[0;31m%s\033[0m%s\n", "ERROR: ", "Failed to Fork");
     exit(EXIT_FAILURE);
   } else if (pidKeepAlive == 0) {
-    char STRING_VPN_KEEPALIVE[sizeof(unsigned int)] = {};
+    char STRING_VPN_KEEPALIVE[0xB] = {};
     sprintf(STRING_VPN_KEEPALIVE, "%u", VPN_KEEPALIVE);
     fclose(stdin);
     freopen("/dev/null", "w", stdout);

--- a/KeepAlive.c
+++ b/KeepAlive.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define likely(x) __builtin_expect((x), 1)
+#define unlikely(x) __builtin_expect((x), 0)
+
+int main(int numArgv, char **arrArgv) {
+  // Refuse to Start if Not Invoked bt Pid=1
+  if (getppid() != 1) {
+    printf("\033[0;31m%s\033[0m%s\n", "ERROR: ", "Must be Invoked by PID 1");
+    exit(EXIT_FAILURE);
+  }
+
+  // Allocate Space for Variables
+  const unsigned int VPN_KEEPALIVE = atoi(arrArgv[1]);
+
+  // Run "ping" to Keep Connection Active
+  while (1) {
+    pid_t pidKeepAlive = fork();
+    if (unlikely(pidKeepAlive == -1)) {
+      printf("\033[0;31m%s\033[0m%s\n", "ERROR: ", "Failed to Fork");
+      exit(EXIT_FAILURE);
+    } else if (pidKeepAlive == 0) {
+      fclose(stdin);
+      freopen("/dev/null", "w", stdout);
+      freopen("/dev/null", "w", stderr);
+      execl("/bin/ping", "ping", "-c", "1", "roundcube.rpi.edu", NULL);
+    }
+    waitpid(pidKeepAlive, NULL, 0);
+    sleep(VPN_KEEPALIVE);
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
<!-- Thank You for Your Pull Request, We Appreciate Any Kinds of Contribution -->

### Description of Changes:

- Separate `KeepAlive` Module from `init`
- `init` Will Now Collecting Zombie Process
- New Execuable `vpnKeepAlive` Placed at `/usr/bin/vpnKeepAlive`

### Type of Changes:
<!-- Replace the Space with an 'x' in the Box Below-->
- [ ] Documentation (Add Documentation to Existing Code)
- [ ] Bug Fix (Non-Breaking Changes Which Fixes an Issue)
- [x] New Feature (Non-Breaking Changes Which Adds Functionality)
- [ ] Improvement (Non-Breaking Changes Which Improves the Structures, Performance, etc...)
- [ ] **Breaking Change** (Breaking Changes that Would Cause Existing Functionality to NOT Work as Expected)

### To-Do or Other Concerns:

- (NONE)